### PR TITLE
Add UserId parameter to AccessValidator

### DIFF
--- a/LT.DigitalOffice.Kernel.nuspec
+++ b/LT.DigitalOffice.Kernel.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>LT.DigitalOffice.Kernel</id>
-    <version>1.1.22</version>
+    <version>1.1.23</version>
     <title>LT.DigitalOffice.Kernel</title>
     <authors>LT Digital Office</authors>
     <owners>LT Digital Office</owners>
@@ -10,9 +10,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Library used in the Digital Office project.</description>
     <releaseNotes>
-1.1.22 - Change MassTransit RequestClients default timeout to (2s). Fix RabbitMQ health check (close connection).
+1.1.23 - Add new AccessValidator parameter (UserId)
 
 Previous versions:
+1.1.22 - Change MassTransit RequestClients default timeout to (2s). Fix RabbitMQ health check (close connection).
 1.1.21 - Change MassTransit RequestClients default timeout to (5s).
 1.1.20 - Add access validator and token auto inject. Add default request timeout (500ms) to MassTransit RequestClients.
 1.1.19 - Rework inject extensions for business ojects and MassTransit RequestClients.

--- a/LT.DigitalOffice.Kernel.nuspec
+++ b/LT.DigitalOffice.Kernel.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>LT.DigitalOffice.Kernel</id>
-    <version>1.1.23</version>
+    <version>1.1.22</version>
     <title>LT.DigitalOffice.Kernel</title>
     <authors>LT Digital Office</authors>
     <owners>LT Digital Office</owners>
@@ -10,10 +10,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Library used in the Digital Office project.</description>
     <releaseNotes>
-1.1.23 - Add new AccessValidator parameter (UserId)
+1.1.22 - Change MassTransit RequestClients default timeout to (2s). Fix RabbitMQ health check (close connection). Add new userId parameter to AccessValidator methods.
 
-Previous versions:
-1.1.22 - Change MassTransit RequestClients default timeout to (2s). Fix RabbitMQ health check (close connection).
+Previous versions: 
 1.1.21 - Change MassTransit RequestClients default timeout to (5s).
 1.1.20 - Add access validator and token auto inject. Add default request timeout (500ms) to MassTransit RequestClients.
 1.1.19 - Rework inject extensions for business ojects and MassTransit RequestClients.

--- a/src/Kernel/AccessValidatorEngine/AccessValidator.cs
+++ b/src/Kernel/AccessValidatorEngine/AccessValidator.cs
@@ -33,14 +33,21 @@ namespace LT.DigitalOffice.Kernel.AccessValidatorEngine
         }
 
         /// <inheritdoc/>
-        public bool HasRights(params int[] rightIds)
+        public bool HasRights(Guid? userId, params int[] rightIds)
         {
             if (rightIds == null || !rightIds.Any())
             {
                 throw new ArgumentException("Can not check empty rights array.", nameof(rightIds));
             }
 
-            _userId = _httpContext.GetUserId();
+            if (userId == null)
+            {
+                _userId = _httpContext.GetUserId();
+            }
+            else
+            {
+                _userId = (Guid)userId;
+            }
 
             Response<IOperationResult<bool>> result = _requestClientCR.GetResponse<IOperationResult<bool>>(
                 ICheckUserRightsRequest.CreateObj(_userId, rightIds),
@@ -55,9 +62,16 @@ namespace LT.DigitalOffice.Kernel.AccessValidatorEngine
         }
 
         /// <inheritdoc/>
-        public bool IsAdmin()
+        public bool IsAdmin(Guid? userId = null)
         {
-            _userId = _httpContext.GetUserId();
+            if (userId == null)
+            {
+                _userId = _httpContext.GetUserId();
+            }
+            else
+            {
+                _userId = (Guid)userId;
+            }
 
             Response<IOperationResult<bool>> result = _requestClientUS.GetResponse<IOperationResult<bool>>(
                 ICheckUserIsAdminRequest.CreateObj(_userId),

--- a/src/Kernel/AccessValidatorEngine/AccessValidator.cs
+++ b/src/Kernel/AccessValidatorEngine/AccessValidator.cs
@@ -30,24 +30,27 @@ namespace LT.DigitalOffice.Kernel.AccessValidatorEngine
             _httpContext = httpContextAccessor.HttpContext;
         }
 
-        private bool CheckUserRights(Guid? userId, int[] rightIds)
+        /// <inheritdoc/>
+        public bool HasRights(params int[] rightIds)
+        {
+            return HasRights(null, rightIds);
+        }
+
+        /// <inheritdoc/>
+        public bool HasRights(Guid? userId, params int[] rightIds)
         {
             if (rightIds == null || !rightIds.Any())
             {
                 throw new ArgumentException("Can not check empty rights array.", nameof(rightIds));
             }
 
-            if (userId == null)
+            if (!userId.HasValue)
             {
                 userId = _httpContext.GetUserId();
             }
-            else
-            {
-                userId = (Guid)userId;
-            }
 
             Response<IOperationResult<bool>> result = _requestClientCR.GetResponse<IOperationResult<bool>>(
-                ICheckUserRightsRequest.CreateObj((Guid)userId, rightIds),
+                ICheckUserRightsRequest.CreateObj(userId.Value, rightIds),
                 timeout: RequestTimeout.After(s: 2)).Result;
 
             if (result.Message == null)
@@ -59,31 +62,15 @@ namespace LT.DigitalOffice.Kernel.AccessValidatorEngine
         }
 
         /// <inheritdoc/>
-        public bool HasRights(params int[] rightIds)
-        {
-            return CheckUserRights(null, rightIds);
-        }
-
-        /// <inheritdoc/>
-        public bool HasRights(Guid? userId, params int[] rightIds)
-        {
-            return CheckUserRights(userId, rightIds);
-        }
-
-        /// <inheritdoc/>
         public bool IsAdmin(Guid? userId = null)
         {
-            if (userId == null)
+            if (!userId.HasValue)
             {
                 userId = _httpContext.GetUserId();
             }
-            else
-            {
-                userId = (Guid)userId;
-            }
 
             Response<IOperationResult<bool>> result = _requestClientUS.GetResponse<IOperationResult<bool>>(
-                ICheckUserIsAdminRequest.CreateObj((Guid)userId),
+                ICheckUserIsAdminRequest.CreateObj(userId.Value),
                 timeout: RequestTimeout.After(s: 2)).Result;
 
             if (result.Message == null)

--- a/src/Kernel/AccessValidatorEngine/Interfaces/IAccessValidator.cs
+++ b/src/Kernel/AccessValidatorEngine/Interfaces/IAccessValidator.cs
@@ -13,12 +13,21 @@ namespace LT.DigitalOffice.Kernel.AccessValidatorEngine.Interfaces
         /// <summary>
         /// Checks whether the user is admin or not.
         /// </summary>
+        /// <param name="userId">Id of the user.</param>
         /// <returns>True, if current user has IsAdmin property set to true in the database. False otherwise.</returns>
         bool IsAdmin(Guid? userId = null);
 
         /// <summary>
         /// Checks whether the user has certain rights.
         /// </summary>
+        /// <param name="rightIds">Ids of the rigths.</param>
+        /// <returns>True, if there's a UserId-RightId pair for all requsted rights in the database. False otherwise.</returns>
+        bool HasRights(params int[] rightIds);
+
+        /// <summary>
+        /// Checks whether the user has certain rights.
+        /// </summary>
+        /// <param name="userId">Id of the user.</param>
         /// <param name="rightIds">Ids of the rigths.</param>
         /// <returns>True, if there's a UserId-RightId pair for all requsted rights in the database. False otherwise.</returns>
         bool HasRights(Guid? userId, params int[] rightIds);

--- a/src/Kernel/AccessValidatorEngine/Interfaces/IAccessValidator.cs
+++ b/src/Kernel/AccessValidatorEngine/Interfaces/IAccessValidator.cs
@@ -1,4 +1,5 @@
 ﻿using LT.DigitalOffice.Kernel.Attributes;
+using System;
 
 namespace LT.DigitalOffice.Kernel.AccessValidatorEngine.Interfaces
 {
@@ -13,13 +14,13 @@ namespace LT.DigitalOffice.Kernel.AccessValidatorEngine.Interfaces
         /// Checks whether the user is admin or not.
         /// </summary>
         /// <returns>True, if current user has IsAdmin property set to true in the database. False otherwise.</returns>
-        bool IsAdmin();
+        bool IsAdmin(Guid? userId = null);
 
         /// <summary>
         /// Checks whether the user has certain rights.
         /// </summary>
         /// <param name="rightIds">Ids of the rigths.</param>
         /// <returns>True, if there's a UserId-RightId pair for all requsted rights in the database. False otherwise.</returns>
-        bool HasRights(params int[] rightIds);
+        bool HasRights(Guid? userId, params int[] rightIds);
     }
 }

--- a/src/Kernel/Kernel.csproj
+++ b/src/Kernel/Kernel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>1.1.22</Version>
+        <Version>1.1.23</Version>
 
         <TargetFramework>net5.0</TargetFramework>
 

--- a/src/Kernel/Kernel.csproj
+++ b/src/Kernel/Kernel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>1.1.23</Version>
+        <Version>1.1.22</Version>
 
         <TargetFramework>net5.0</TargetFramework>
 

--- a/test/Kernel.UnitTests/AccessValidatorEngine/AccessValidatorTests.cs
+++ b/test/Kernel.UnitTests/AccessValidatorEngine/AccessValidatorTests.cs
@@ -21,7 +21,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
         private Mock<IOperationResult<bool>> _operationResultMock;
         private Mock<HttpContext> _httpContextMock;
 
-        private string _userId;
+        private Guid _userId;
         private IAccessValidator _accessValidator;
 
         private int[] RightIds = new [] { 5, 4 };
@@ -61,7 +61,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            _userId = Guid.NewGuid().ToString();
+            _userId = Guid.NewGuid();
 
             BrokerSetUp();
 
@@ -83,7 +83,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
         {
             _httpContextMock
                 .Setup(x => x.Items[ConstStrings.UserId])
-                .Returns(_userId);
+                .Returns(_userId.ToString());
 
             _httpContextMock
                 .Setup(x => x.Items.ContainsKey(ConstStrings.UserId))
@@ -96,6 +96,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
             ConfigureOperationResult(true, true);
 
             Assert.IsTrue(_accessValidator.IsAdmin());
+            Assert.IsTrue(_accessValidator.IsAdmin(_userId));
         }
 
         [Test]
@@ -104,6 +105,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
             ConfigureOperationResult(true, false);
 
             Assert.IsFalse(_accessValidator.IsAdmin());
+            Assert.IsFalse(_accessValidator.IsAdmin(Guid.NewGuid()));
         }
 
         [Test]
@@ -123,7 +125,8 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
         {
             ConfigureOperationResult(true, true);
 
-            Assert.IsTrue(_accessValidator.HasRights(RightIds));
+            Assert.IsTrue(_accessValidator.HasRights(null, RightIds));
+            Assert.IsTrue(_accessValidator.HasRights(_userId, RightIds));
         }
 
         [Test]
@@ -131,7 +134,8 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
         {
             ConfigureOperationResult(true, false);
 
-            Assert.IsFalse(_accessValidator.HasRights(RightIds));
+            Assert.IsFalse(_accessValidator.HasRights(null, RightIds));
+            Assert.IsFalse(_accessValidator.HasRights(Guid.NewGuid(), RightIds));
         }
 
         [Test]
@@ -142,7 +146,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
                 .Returns((IOperationResult<bool>)null);
 
             Assert.Throws<NullReferenceException>(
-                () => _accessValidator.HasRights(RightIds),
+                () => _accessValidator.HasRights(null, RightIds),
                 "Failed to send request to CheckRightService via the broker.");
         }
 
@@ -160,7 +164,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
                 $"UserId '{text}' value in HttpContext is not in Guid format.");
 
             Assert.Throws<InvalidCastException>(
-                () => _accessValidator.HasRights(RightIds),
+                () => _accessValidator.HasRights(null, RightIds),
                 $"UserId '{text}' value in HttpContext is not in Guid format.");
         }
 
@@ -176,7 +180,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
                 "UserId value in HttpContext is empty.");
 
             Assert.Throws<ArgumentException>(
-                () => _accessValidator.HasRights(RightIds),
+                () => _accessValidator.HasRights(null, RightIds),
                 "UserId value in HttpContext is empty.");
         }
 
@@ -192,7 +196,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
                 "HttpContext does not contain UserId.");
 
             Assert.Throws<ArgumentNullException>(
-                () => _accessValidator.HasRights(RightIds),
+                () => _accessValidator.HasRights(null, RightIds),
                 "HttpContext does not contain UserId.");
         }
     }

--- a/test/Kernel.UnitTests/AccessValidatorEngine/AccessValidatorTests.cs
+++ b/test/Kernel.UnitTests/AccessValidatorEngine/AccessValidatorTests.cs
@@ -125,6 +125,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
         {
             ConfigureOperationResult(true, true);
 
+            Assert.IsTrue(_accessValidator.HasRights(RightIds));
             Assert.IsTrue(_accessValidator.HasRights(null, RightIds));
             Assert.IsTrue(_accessValidator.HasRights(_userId, RightIds));
         }
@@ -134,6 +135,7 @@ namespace LT.DigitalOffice.Kernel.UnitTests.AccessValidatorEngine
         {
             ConfigureOperationResult(true, false);
 
+            Assert.IsFalse(_accessValidator.HasRights(RightIds));
             Assert.IsFalse(_accessValidator.HasRights(null, RightIds));
             Assert.IsFalse(_accessValidator.HasRights(Guid.NewGuid(), RightIds));
         }


### PR DESCRIPTION
Motivation: if there is no context, then you can pass the UserId, and not create it from scratch