### PR TITLE
Add Environment to BaseServiceInfoConfig

### DIFF
--- a/LT.DigitalOffice.Kernel.nuspec
+++ b/LT.DigitalOffice.Kernel.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>LTDO.Kernel</id>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
         <title>DigitalOffice.Kernel</title>
         <authors>Lanit-Tercom Digital Office Team</authors>
         <owners>Lanit-Tercom Digital Office</owners>
@@ -10,9 +10,10 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Library used in the Digital Office project.</description>
         <releaseNotes>
-            2.0.6 - fix BaseFindFilter.
+            2.0.7 - extend BaseServiceInfoConfig.
 
             Previous versions:
+            2.0.6 - fix BaseFindFilter.
             2.0.5 - tweak 'ApplyFilter' extension method.
             2.0.4 - Add 'ApplyFilter' extension method.
             2.0.3 - Add 'AddEditRemovePrProcesses' constant for Rights.

--- a/src/Kernel/Configurations/BaseServiceInfoConfig.cs
+++ b/src/Kernel/Configurations/BaseServiceInfoConfig.cs
@@ -6,4 +6,5 @@ public class BaseServiceInfoConfig
 
   public string Id { get; init; }
   public string Name { get; init; }
+  public string Environment { get; set; }
 }

--- a/src/Kernel/Kernel.csproj
+++ b/src/Kernel/Kernel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <Version>2.0.6</Version>
+      <Version>2.0.7</Version>
 
       <TargetFramework>net8.0</TargetFramework>
 


### PR DESCRIPTION
Review order:
1. Add property for storing global environment value
2. [Add environment variable for global environment](https://gitlab.digital-office.dso.lanit-tercom.com/digital-office/Platform/-/merge_requests/11)
3. [Extend feedback to support environments](https://gitlab.digital-office.dso.lanit-tercom.com/digital-office/backend/FeedbackService/-/merge_requests/29)
4. [Add assigning global env value on feedback creating](https://gitlab.digital-office.dso.lanit-tercom.com/digital-office/backend/Gateway/-/merge_requests/57)
5. [Update text template for feedback](https://gitlab.digital-office.dso.lanit-tercom.com/digital-office/backend/TextTemplateService/-/merge_requests/28)